### PR TITLE
Updates for SPT 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom ignores
 project/References/EFT_Managed/*
+project/References/SPT/*
 
 # Allow these files, despite the rules above
 !project/References/EFT_Managed/.keep

--- a/project/Terkoiz.Freecam/CameraForceSetPositionPatch.cs
+++ b/project/Terkoiz.Freecam/CameraForceSetPositionPatch.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using SPT.Reflection.Patching;
+using System.Reflection;
+
+namespace Terkoiz.Freecam
+{
+    public class CameraForceSetPositionPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(CameraClass), nameof(CameraClass.ForceSetPosition));
+        }
+
+        [PatchPrefix]
+        public static bool PatchPrefix()
+        {
+            // When FreeCam is active, prevent EFT from snapping the camera back to the player's head
+            if (FreecamController.IsFreeCamScriptActive)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/project/Terkoiz.Freecam/FreecamController.cs
+++ b/project/Terkoiz.Freecam/FreecamController.cs
@@ -10,9 +10,10 @@ namespace Terkoiz.Freecam
 {
     public class FreecamController : MonoBehaviour
     {
-        private GameObject _mainCamera;
-        private Freecam _freeCamScript;
+        private static Freecam _freeCamScript;
 
+        private GameObject _mainCamera;
+        
         private EftBattleUIScreen _playerUi;
         private bool _uiHidden;
 
@@ -20,6 +21,8 @@ namespace Terkoiz.Freecam
 
         private Vector3? _lastPosition;
         private Quaternion? _lastRotation;
+
+        public static bool IsFreeCamScriptActive => _freeCamScript.IsActive;
 
         [UsedImplicitly]
         public void Start()

--- a/project/Terkoiz.Freecam/FreecamPlugin.cs
+++ b/project/Terkoiz.Freecam/FreecamPlugin.cs
@@ -7,7 +7,7 @@ using KeyboardShortcut = BepInEx.Configuration.KeyboardShortcut;
 
 namespace Terkoiz.Freecam
 {
-    [BepInPlugin("com.terkoiz.freecam", "Terkoiz.Freecam", "1.4.5")]
+    [BepInPlugin("com.terkoiz.freecam", "Terkoiz.Freecam", "1.5.0")]
     public class FreecamPlugin : BaseUnityPlugin
     {
         internal new static ManualLogSource Logger { get; private set; }
@@ -46,6 +46,7 @@ namespace Terkoiz.Freecam
 
             new FreecamPatch().Enable();
             new FallDamagePatch().Enable();
+            new CameraForceSetPositionPatch().Enable();
         }
 
         private void InitConfiguration()

--- a/project/Terkoiz.Freecam/Terkoiz.Freecam.csproj
+++ b/project/Terkoiz.Freecam/Terkoiz.Freecam.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <Reference Include="Aki.Reflection">
-      <HintPath>..\References\SPT\spt-reflection.dll</HintPath>
+	  <HintPath>..\References\SPT\spt-reflection.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
@@ -30,6 +30,10 @@
     <Reference Include="Comfort.Unity">
       <HintPath>..\References\EFT_Managed\Comfort.Unity.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Sirenix.Serialization">
+      <HintPath>..\References\EFT_Managed\Sirenix.Serialization.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\References\EFT_Managed\UnityEngine.dll</HintPath>


### PR DESCRIPTION
Made the following updates so this will work with SPT 3.11:
* Added a reference to Sirenix.Serialization (now required)
* Added a patch to prevent EFT from snapping the camera back to the player's head. This seems like an anti-cheat measure BSG added since SPT 3.10. 

I also added _project/References/SPT/*_ to .gitignore so VS wouldn't try uploading SPT DLL's. Feel free to delete that change if I'm overlooking something. 